### PR TITLE
Add missing get component in children attribute

### DIFF
--- a/AttachComponents.meta
+++ b/AttachComponents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3f21cf050985f245bc5f883659f2acf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AttachComponents/Attributes.meta
+++ b/AttachComponents/Attributes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b8bb5da8004b0ea49901dec38fde0c4b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AttachComponents/Attributes/AttachAttributes.cs
+++ b/AttachComponents/Attributes/AttachAttributes.cs
@@ -3,5 +3,17 @@ using System;
 using UnityEngine;
 
 [AttributeUsage(System.AttributeTargets.Field)] public class GetComponentAttribute : PropertyAttribute { }
+
+[AttributeUsage(System.AttributeTargets.Field)]
+public class GetComponentInChildrenAttribute : PropertyAttribute
+{
+    public bool IncludeInactive { get; private set; }
+
+    public GetComponentInChildrenAttribute(bool includeInactive)
+    {
+        IncludeInactive = includeInactive;
+    }
+}
+
 [AttributeUsage(System.AttributeTargets.Field)] public class AddComponentAttribute : PropertyAttribute { }
 [AttributeUsage(System.AttributeTargets.Field)] public class FindObjectOfTypeAttribute : PropertyAttribute { }

--- a/AttachComponents/Attributes/AttachAttributes.cs.meta
+++ b/AttachComponents/Attributes/AttachAttributes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b46ce8ce45ac7d743b075a7fcf098d23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AttachComponents/Editor.meta
+++ b/AttachComponents/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 043622a1c21f8a9408b81b044cab6060
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AttachComponents/Editor/AttachAttributesEditor.cs.meta
+++ b/AttachComponents/Editor/AttachAttributesEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6e78c00e20078645ae24557eaa95e31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Nrjwolf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 887821fc0b22a6e43965f9a3c51a984c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 90e1cd9b004fef548abcfaab0219ca39
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Summary
Add missing implementation of `GetComponentInChildrenAttribute`.

### Details
Using `master` branch of the repository causes compilation errors when using `GetComponentInChildren` attribute like mentioned in README.md:
```csharp
    [GetComponentInChildren(true)]
    [SerializeField]
    private Button m_Button;
```
Fixed that by adding attribute implementation in efbdad496fe0138c3237d15406c8f37b04573c55.

Bonus fixes:
* Add `.meta` files. They are added to allow usage of the repository as submodule in Unity project. Otherwise git shows Unity generated `.meta` files as newly added ones.
* Add LICENSE.md with MIT license. MIT is selected based on the project https://github.com/Nrjwolf/unity-ios-easy-native-alert licensed under MIT.

### How to test
Checkout target branch and create test script which uses `GetComponentInChildren` attribute. Observe compilation error. Checkout source branch and observe no compilation error.

Closes #1 